### PR TITLE
Debug web app login path error

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Stopwatch Magic - Weiterleitung...</title>
-    <meta http-equiv="refresh" content="0; url=/magician/login.html">
-    <link rel="canonical" href="/magician/login.html">
+    <meta http-equiv="refresh" content="0; url=/maintick/login.html">
+    <link rel="canonical" href="/maintick/login.html">
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -52,14 +52,14 @@
     <div style="font-size: 14px; opacity: 0.8; margin-bottom: 20px;">
         Weiterleitung zum Login...
     </div>
-    <a href="/magician/login.html" class="link">
+    <a href="/maintick/login.html" class="link">
         Klicken Sie hier, falls die Weiterleitung nicht funktioniert
     </a>
     
     <script>
         // Zusätzliche JavaScript-Weiterleitung für maximale Kompatibilität
         setTimeout(() => {
-            window.location.href = '/magician/login.html';
+            window.location.href = '/maintick/login.html';
         }, 100);
     </script>
 </body>

--- a/public/js/magician.js
+++ b/public/js/magician.js
@@ -4,7 +4,7 @@ const Magician = (function(){
     // check login
     const s = await fetch('/auth/status').then(r=>r.json());
     if (!s.loggedIn) {
-      location.href = '/magician/login.html';
+      location.href = '/maintick/login.html';
       return;
     }
     // load tokens
@@ -22,7 +22,7 @@ const Magician = (function(){
         el.style.padding='8px'; el.style.borderBottom='1px solid rgba(255,255,255,0.06)';
         el.innerHTML = `<strong>${t.token}</strong> &nbsp; queued: ${t.queued} &nbsp; <button class="btnOpen">Öffnen</button> <button class="btnDel" style="margin-left:8px">Löschen</button>`;
         el.querySelector('.btnOpen').addEventListener('click', ()=> {
-          window.open(`/magician/stopwatch-admin.html?token=${encodeURIComponent(t.token)}`, '_blank');
+          window.open(`/maintick/stopwatch.html?token=${encodeURIComponent(t.token)}`, '_blank');
         });
         el.querySelector('.btnDel').addEventListener('click', async ()=> {
           if (!confirm('Token löschen?')) return;
@@ -46,7 +46,7 @@ const Magician = (function(){
 
   async function logout(){
     await fetch('/auth/logout', { method:'POST' });
-    location.href = '/magician/login.html';
+    location.href = '/maintick/login.html';
   }
 
   return { init, createToken, logout };

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "Stopwatch Magic",
   "short_name": "Stopwatch",  
   "description": "Magische Stoppuhr für Bühnenzauber",
-  "start_url": "/magician/login.html?pwa=true",
+  "start_url": "/maintick/login.html?pwa=true",
   "display": "fullscreen",
   "orientation": "portrait",
   "theme_color": "#000000",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,11 +1,11 @@
 // sw.js - Service Worker für Stopwatch Magic PWA
-const CACHE_NAME = 'stopwatch-magic-v1';
+const CACHE_NAME = 'stopwatch-magic-v2';
 const urlsToCache = [
   '/',
-  '/spectator.html',
-  '/magician/login.html',
-  '/magician/dashboard.html',
-  '/magician/stopwatch-admin.html',
+  '/modultick.html',
+  '/maintick/login.html',
+  '/maintick/dashboard.html',
+  '/maintick/stopwatch.html',
   '/js/stopwatch.js',
   '/js/shared.js',
   '/js/magician.js',


### PR DESCRIPTION
Corrects PWA and internal path references from `/magician/` to `/maintick/` to fix 'Cannot GET' errors when installed as a web app.

The application was refactored, moving files from a `/magician/` directory to `/maintick/`. However, the `manifest.json`, service worker cache, and some internal JavaScript links were not updated, causing the PWA to attempt to load non-existent paths like `/magician/login.html` and other related resources. This PR updates all these references to the correct `/maintick/` paths and also corrects a specific file name (`spectator.html` to `modultick.html`) in the service worker cache.

---
<a href="https://cursor.com/background-agent?bcId=bc-954910f6-ead8-44a8-b434-784d6aa40c5b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-954910f6-ead8-44a8-b434-784d6aa40c5b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

