### PR TITLE
Configure web app manifest and iOS redirect

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,10 +2,20 @@
 <html lang="de">
 <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Stopwatch Magic - Weiterleitung...</title>
-    <meta http-equiv="refresh" content="0; url=/maintick/login.html">
-    <link rel="canonical" href="/maintick/login.html">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <title>IMPERIA Magic System</title>
+    
+    <!-- PWA Meta Tags -->
+    <link rel="manifest" href="/manifest.json">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="IMPERIA">
+    <link rel="apple-touch-icon" href="/icon-192x192.png">
+    <link rel="icon" type="image/png" href="/icon-192x192.png">
+    <meta name="theme-color" content="#000000">
+    
+    <meta http-equiv="refresh" content="0; url=/license.html">
+    <link rel="canonical" href="/license.html">
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -48,18 +58,27 @@
 </head>
 <body>
     <div class="spinner"></div>
-    <div class="message">🎩 Stopwatch Magic</div>
+    <div class="message">🎩 IMPERIA Magic System</div>
     <div style="font-size: 14px; opacity: 0.8; margin-bottom: 20px;">
-        Weiterleitung zum Login...
+        Weiterleitung zur App...
     </div>
-    <a href="/maintick/login.html" class="link">
+    <a href="/license.html" class="link">
         Klicken Sie hier, falls die Weiterleitung nicht funktioniert
     </a>
     
     <script>
+        // Register service worker if supported
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', () => {
+                navigator.serviceWorker.register('/sw.js')
+                    .then(registration => console.log('Service Worker registered'))
+                    .catch(err => console.log('Service Worker registration failed:', err));
+            });
+        }
+        
         // Zusätzliche JavaScript-Weiterleitung für maximale Kompatibilität
         setTimeout(() => {
-            window.location.href = '/maintick/login.html';
+            window.location.href = '/license.html';
         }, 100);
     </script>
 </body>

--- a/public/license.html
+++ b/public/license.html
@@ -1,0 +1,319 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="IMPERIA">
+    <title>IMPERIA Magic System - Lizenzbestätigung</title>
+    
+    <!-- PWA Meta Tags -->
+    <link rel="manifest" href="/manifest.json">
+    <link rel="apple-touch-icon" href="/icon-192x192.png">
+    <link rel="icon" type="image/png" href="/icon-192x192.png">
+    
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: #000;
+            color: #fff;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            overflow-x: hidden;
+        }
+        
+        .container {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            padding: 20px;
+            max-width: 600px;
+            margin: 0 auto;
+            width: 100%;
+        }
+        
+        .header {
+            text-align: center;
+            margin-bottom: 30px;
+            padding-top: 20px;
+        }
+        
+        .logo {
+            width: 80px;
+            height: 80px;
+            margin: 0 auto 20px;
+            background: linear-gradient(135deg, #007AFF 0%, #0051D5 100%);
+            border-radius: 20px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 40px;
+            box-shadow: 0 4px 20px rgba(0, 122, 255, 0.3);
+        }
+        
+        h1 {
+            font-size: 28px;
+            font-weight: 600;
+            margin-bottom: 10px;
+        }
+        
+        .subtitle {
+            font-size: 16px;
+            color: #999;
+            margin-bottom: 30px;
+        }
+        
+        .license-box {
+            background: #1a1a1a;
+            border-radius: 12px;
+            padding: 20px;
+            margin-bottom: 30px;
+            border: 1px solid #333;
+        }
+        
+        .license-title {
+            font-size: 18px;
+            font-weight: 600;
+            margin-bottom: 15px;
+            color: #007AFF;
+        }
+        
+        .license-text {
+            font-size: 14px;
+            line-height: 1.6;
+            color: #ccc;
+            margin-bottom: 20px;
+        }
+        
+        .license-terms {
+            background: #0a0a0a;
+            border-radius: 8px;
+            padding: 15px;
+            margin-bottom: 20px;
+            max-height: 300px;
+            overflow-y: auto;
+            font-size: 13px;
+            line-height: 1.5;
+            color: #aaa;
+        }
+        
+        .checkbox-container {
+            display: flex;
+            align-items: flex-start;
+            margin-bottom: 30px;
+            padding: 15px;
+            background: #1a1a1a;
+            border-radius: 8px;
+            border: 1px solid #333;
+        }
+        
+        .checkbox {
+            width: 20px;
+            height: 20px;
+            min-width: 20px;
+            margin-right: 12px;
+            margin-top: 2px;
+            cursor: pointer;
+        }
+        
+        .checkbox-label {
+            font-size: 14px;
+            line-height: 1.5;
+            cursor: pointer;
+            user-select: none;
+        }
+        
+        .btn-container {
+            margin-top: auto;
+            padding-bottom: 20px;
+        }
+        
+        .btn {
+            width: 100%;
+            padding: 16px;
+            font-size: 16px;
+            font-weight: 600;
+            border: none;
+            border-radius: 12px;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            text-decoration: none;
+            display: block;
+            text-align: center;
+        }
+        
+        .btn-primary {
+            background: linear-gradient(135deg, #007AFF 0%, #0051D5 100%);
+            color: white;
+            box-shadow: 0 4px 15px rgba(0, 122, 255, 0.3);
+        }
+        
+        .btn-primary:hover:not(:disabled) {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 20px rgba(0, 122, 255, 0.4);
+        }
+        
+        .btn-primary:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+            transform: none;
+        }
+        
+        .error-message {
+            background: #ff3b304d;
+            border: 1px solid #ff3b30;
+            color: #ff3b30;
+            padding: 12px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+            font-size: 14px;
+            display: none;
+        }
+        
+        /* PWA specific styles */
+        @media (display-mode: standalone) {
+            .header {
+                padding-top: 40px; /* Extra padding for status bar */
+            }
+        }
+        
+        /* Scrollbar styling */
+        .license-terms::-webkit-scrollbar {
+            width: 6px;
+        }
+        
+        .license-terms::-webkit-scrollbar-track {
+            background: #1a1a1a;
+            border-radius: 3px;
+        }
+        
+        .license-terms::-webkit-scrollbar-thumb {
+            background: #444;
+            border-radius: 3px;
+        }
+        
+        .license-terms::-webkit-scrollbar-thumb:hover {
+            background: #555;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <div class="logo">🎩</div>
+            <h1>IMPERIA Magic System</h1>
+            <div class="subtitle">Professionelles Zauber-System</div>
+        </div>
+        
+        <div class="error-message" id="errorMessage">
+            Bitte akzeptieren Sie die Lizenzbedingungen, um fortzufahren.
+        </div>
+        
+        <div class="license-box">
+            <div class="license-title">Endbenutzer-Lizenzvereinbarung</div>
+            <div class="license-text">
+                Bitte lesen Sie die folgenden Lizenzbedingungen sorgfältig durch:
+            </div>
+            
+            <div class="license-terms">
+                <h3>1. Lizenzgewährung</h3>
+                <p>Diese Software wird Ihnen zur persönlichen Nutzung lizenziert. Die Nutzung ist auf registrierte Benutzer beschränkt.</p>
+                
+                <h3>2. Nutzungsbeschränkungen</h3>
+                <p>Sie dürfen die Software nicht:</p>
+                <ul>
+                    <li>Kopieren, modifizieren oder verteilen</li>
+                    <li>Reverse-Engineering betreiben</li>
+                    <li>Für illegale Zwecke verwenden</li>
+                    <li>An Dritte weitergeben</li>
+                </ul>
+                
+                <h3>3. Geistiges Eigentum</h3>
+                <p>Alle Rechte an der Software und den Inhalten verbleiben beim Hersteller.</p>
+                
+                <h3>4. Haftungsausschluss</h3>
+                <p>Die Software wird "wie besehen" zur Verfügung gestellt. Der Hersteller übernimmt keine Haftung für Schäden.</p>
+                
+                <h3>5. Datenschutz</h3>
+                <p>Ihre Daten werden gemäß unserer Datenschutzrichtlinie behandelt und geschützt.</p>
+                
+                <h3>6. Kündigung</h3>
+                <p>Diese Lizenz kann bei Verstoß gegen die Bedingungen jederzeit gekündigt werden.</p>
+                
+                <h3>7. Geltendes Recht</h3>
+                <p>Es gilt das Recht der Bundesrepublik Deutschland.</p>
+            </div>
+        </div>
+        
+        <div class="checkbox-container">
+            <input type="checkbox" id="acceptTerms" class="checkbox">
+            <label for="acceptTerms" class="checkbox-label">
+                Ich habe die Lizenzbedingungen gelesen und akzeptiere sie. Ich bestätige, dass ich berechtigt bin, diese Software zu nutzen.
+            </label>
+        </div>
+        
+        <div class="btn-container">
+            <button id="continueBtn" class="btn btn-primary" disabled>
+                Weiter zur App
+            </button>
+        </div>
+    </div>
+    
+    <script>
+        // Check if running as PWA
+        const isPWA = window.matchMedia('(display-mode: standalone)').matches ||
+                     window.navigator.standalone ||
+                     document.referrer.includes('android-app://');
+        
+        // License acceptance logic
+        const checkbox = document.getElementById('acceptTerms');
+        const continueBtn = document.getElementById('continueBtn');
+        const errorMessage = document.getElementById('errorMessage');
+        
+        // Check if license was already accepted
+        const licenseAccepted = localStorage.getItem('licenseAccepted');
+        
+        // If already accepted and running as PWA, redirect immediately
+        if (licenseAccepted === 'true' && isPWA) {
+            window.location.href = '/maintick/login.html';
+        }
+        
+        checkbox.addEventListener('change', function() {
+            continueBtn.disabled = !this.checked;
+            if (this.checked) {
+                errorMessage.style.display = 'none';
+            }
+        });
+        
+        continueBtn.addEventListener('click', function() {
+            if (checkbox.checked) {
+                // Save license acceptance
+                localStorage.setItem('licenseAccepted', 'true');
+                localStorage.setItem('licenseAcceptedDate', new Date().toISOString());
+                
+                // Redirect to main app
+                window.location.href = '/maintick/login.html';
+            } else {
+                errorMessage.style.display = 'block';
+            }
+        });
+        
+        // Register service worker if supported
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', () => {
+                navigator.serviceWorker.register('/sw.js')
+                    .then(registration => console.log('Service Worker registered'))
+                    .catch(err => console.log('Service Worker registration failed:', err));
+            });
+        }
+    </script>
+</body>
+</html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "IMPERIA Magic System",
   "short_name": "IMPERIA",  
   "description": "Professionelles Zauber-System für Bühnenkünstler",
-  "start_url": "/maintick/stopwatch.html?pwa=true",
+  "start_url": "/license.html?source=pwa",
   "display": "fullscreen",
   "orientation": "portrait",
   "theme_color": "#000000",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,8 @@
-// sw.js - Service Worker für Stopwatch Magic PWA
-const CACHE_NAME = 'stopwatch-magic-v5';
+// sw.js - Service Worker für IMPERIA Magic System PWA
+const CACHE_NAME = 'imperia-magic-v6';
 const urlsToCache = [
   '/',
+  '/license.html',
   '/modultick.html',
   '/maintick/login.html',
   '/maintick/dashboard.html',


### PR DESCRIPTION
Add a mandatory license agreement screen for PWA first-time launches on iOS.

---
<a href="https://cursor.com/background-agent?bcId=bc-950f187b-c181-4677-8adc-6b096ad56116">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-950f187b-c181-4677-8adc-6b096ad56116">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

