### PR TITLE
Fix cannot GET /control/index.html on iOS shortcut

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "IMPERIA Magic System",
   "short_name": "IMPERIA",
   "description": "Professional Magic Performance Timer",
-  "start_url": "/control/index.html?source=pwa",
+  "start_url": "/index.html?source=pwa",
   "display": "standalone",
   "background_color": "#000000",
   "theme_color": "#000000",

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 const CACHE_NAME = 'imperia-v4';
 const urlsToCache = [
   '/',
-  '/control/index.html',
+  '/index.html',
   '/manifest.json',
   '/icon-192x192.png',
   '/icon-512x512.png'


### PR DESCRIPTION
Fixes "cannot GET /control/index.html" error by correcting the PWA start URL and service worker cache path.

The `manifest.json` and `sw.js` files incorrectly pointed to `/control/index.html`, which does not exist in the root public directory, leading to a broken PWA experience on iOS. The main PWA should point to the root `index.html`.

---
<a href="https://cursor.com/background-agent?bcId=bc-086fb7c0-9883-4e49-8580-737186026ddb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-086fb7c0-9883-4e49-8580-737186026ddb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

