### PR TITLE
Fix imperia controll broken links

### DIFF
--- a/public/imperia/control/instructions.html
+++ b/public/imperia/control/instructions.html
@@ -206,7 +206,7 @@
 </head>
 <body>
     <div class="header">
-        <a href="/control/menu.html" class="back-btn">← Zurück</a>
+        <a href="/imperia/control/menu.html" class="back-btn">← Zurück</a>
         <h1>Anleitungen</h1>
         <div style="width: 80px;"></div>
     </div>

--- a/public/imperia/control/login.html
+++ b/public/imperia/control/login.html
@@ -198,7 +198,7 @@
             </div>
         </form>
         
-        <a href="/control/" class="back-link">Zurück zur Lizenz-Eingabe</a>
+        <a href="/imperia/control/" class="back-link">Zurück zur Lizenz-Eingabe</a>
         
         <div class="error" id="errorMsg"></div>
     </div>

--- a/public/imperia/control/menu.html
+++ b/public/imperia/control/menu.html
@@ -6,7 +6,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes"/>
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent"/>
     <meta name="apple-mobile-web-app-title" content="Imperia"/>
-    <link rel="apple-touch-icon" href="/icon-192x192.png"/>
+    <link rel="apple-touch-icon" href="/imperia/icon-192x192.png"/>
     <title>Imperia - Main Menu</title>
     <style>
         * {
@@ -160,15 +160,15 @@
     </div>
     
     <div class="menu-container">
-        <a href="/control/routines.html" class="menu-item">
+        <a href="/imperia/control/routines.html" class="menu-item">
             <div class="menu-title">Routinen</div>
         </a>
         
-        <a href="/control/instructions.html" class="menu-item">
+        <a href="/imperia/control/instructions.html" class="menu-item">
             <div class="menu-title">Anleitungen</div>
         </a>
         
-        <a href="/control/settings.html" class="menu-item">
+        <a href="/imperia/control/settings.html" class="menu-item">
             <div class="menu-title">Einstellungen</div>
         </a>
     </div>

--- a/public/imperia/control/routines.html
+++ b/public/imperia/control/routines.html
@@ -171,7 +171,7 @@
 </head>
 <body>
     <div class="header">
-        <a href="/control/menu.html" class="back-btn">← Zurück</a>
+        <a href="/imperia/control/menu.html" class="back-btn">← Zurück</a>
         <h1>Routinen</h1>
         <div style="width: 80px;"></div>
     </div>
@@ -184,7 +184,7 @@
             </div>
             
             <div class="app-grid">
-                <a href="/maintick/stopwatch.html" class="app-card" id="mainTickCard">
+                <a href="/imperia/tempra/stopwatch.html" class="app-card" id="mainTickCard">
                     <div class="app-icon">⏱️</div>
                     <div class="app-name">MainTick</div>
                     <div class="app-status status-active">Verfügbar</div>

--- a/public/imperia/control/settings.html
+++ b/public/imperia/control/settings.html
@@ -303,7 +303,7 @@
 </head>
 <body>
     <div class="header">
-        <a href="/control/menu.html" class="back-btn">← Zurück</a>
+        <a href="/imperia/control/menu.html" class="back-btn">← Zurück</a>
         <h1>Einstellungen</h1>
         <div style="width: 80px;"></div>
     </div>


### PR DESCRIPTION
Fix broken links in Imperia Control by prefixing paths with `/imperia` to resolve "Cannot GET" errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8b969ba-6181-4993-b553-fd31b70698b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b8b969ba-6181-4993-b553-fd31b70698b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

