### PR TITLE
Investigate missing imperia remote settings

### DIFF
--- a/public/imperia/control/settings.html
+++ b/public/imperia/control/settings.html
@@ -528,32 +528,42 @@
         // Load tokens
         async function loadTokens() {
             try {
-                const response = await fetch('/api/tokens', {
+                const response = await fetch('/api/user/tokens', {
                     credentials: 'include'
                 });
                 
-                if (response.ok) {
-                    const data = await response.json();
-                    const apiTokenDisplay = document.getElementById('apiTokenDisplay');
-                    apiTokenDisplay.classList.remove('loading', 'show');
-                    
-                    if (data.tokens.length === 0) {
-                        apiTokenDisplay.innerHTML = '<p style="text-align: center; opacity: 0.6;">Kein Token vorhanden</p>';
-                    } else {
-                        const token = data.tokens[0].value;
-                        apiTokenDisplay.innerHTML = `
-                            <div style="display: flex; align-items: center; gap: 12px;">
-                                <span style="font-weight: 600;">API Token =</span>
-                                <span style="font-family: monospace; background: rgba(255,255,255,0.1); padding: 8px 12px; border-radius: 6px;">${token}</span>
-                            </div>
-                        `;
-                        
-                        // Update remote URLs
-                        updateRemoteUrl(token);
-                    }
+                const apiTokenDisplay = document.getElementById('apiTokenDisplay');
+                apiTokenDisplay.classList.remove('loading', 'show');
+                
+                if (!response.ok) {
+                    apiTokenDisplay.innerHTML = '<p style="text-align: center; opacity: 0.6;">Token konnten nicht geladen werden</p>';
+                    return;
                 }
+                
+                const data = await response.json();
+                const token = data && data.token ? data.token : null;
+                
+                if (!token) {
+                    apiTokenDisplay.innerHTML = '<p style="text-align: center; opacity: 0.6;">Kein Token vorhanden</p>';
+                    updateRemoteUrl(null);
+                    return;
+                }
+                
+                apiTokenDisplay.innerHTML = `
+                    <div style="display: flex; align-items: center; gap: 12px;">
+                        <span style="font-weight: 600;">API Token =</span>
+                        <span style="font-family: monospace; background: rgba(255,255,255,0.1); padding: 8px 12px; border-radius: 6px;">${token}</span>
+                    </div>
+                `;
+                
+                // Update remote URL
+                updateRemoteUrl(token);
             } catch (error) {
                 console.error('Error loading tokens:', error);
+                const apiTokenDisplay = document.getElementById('apiTokenDisplay');
+                apiTokenDisplay.classList.remove('loading', 'show');
+                apiTokenDisplay.innerHTML = '<p style="text-align: center; opacity: 0.6;">Fehler beim Laden der Tokens</p>';
+                updateRemoteUrl(null);
             }
         }
         
@@ -568,11 +578,12 @@
             }
             
             const baseUrl = window.location.origin;
+            const remoteUrl = `${baseUrl}/imperia/remote/${token}`;
             
             remoteAccessDisplay.innerHTML = `
                 <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 16px;">
                     <span style="font-weight: 600;">Remote-Zugang =</span>
-                    <span style="font-family: monospace; background: rgba(255,255,255,0.1); padding: 8px 12px; border-radius: 6px;">${baseUrl}/imperia/remote/index.html?token=${token}</span>
+                    <span style="font-family: monospace; background: rgba(255,255,255,0.1); padding: 8px 12px; border-radius: 6px;">${remoteUrl}</span>
                 </div>
             `;
         }

--- a/public/imperia/sw.js
+++ b/public/imperia/sw.js
@@ -1,6 +1,6 @@
 // sw.js - Service Worker für IMPERIA Control System PWA
 // Updated: 2024-01-15
-const CACHE_NAME = 'imperia-control-v7-2024-01-15';
+const CACHE_NAME = 'imperia-control-v8-2025-08-18';
 const urlsToCache = [
   '/imperia/',
   '/imperia/control/index.html',

--- a/server.js
+++ b/server.js
@@ -498,7 +498,7 @@ app.get('/api/user/tokens', requireDB, async (req, res) => {
         const baseUrl = `${protocol}://${host}`;
 
         const apiExamples = {
-            remoteUrl: `${baseUrl}/imperia/remote/index.html?token=${token.token}`,
+            remoteUrl: `${baseUrl}/imperia/remote/${token.token}`,
             pushForce: {
                 url: `${baseUrl}/api/data/${token.token}`,
                 method: 'POST',


### PR DESCRIPTION
Fixes display of API tokens and IMPERIA Remote URL in settings.

The settings page was incorrectly calling the `/api/tokens` endpoint, which is unauthorized for regular users, instead of `/api/user/tokens`. This prevented tokens and the remote URL from being displayed. Also, the remote URL format was updated to match the expected path-based format (`/imperia/remote/{TOKEN}`).

---
<a href="https://cursor.com/background-agent?bcId=bc-87d1df29-15af-4809-9544-233bb27c974d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-87d1df29-15af-4809-9544-233bb27c974d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

