### PR TITLE
Investigate missing imperia remote settings

### DIFF
--- a/public/imperia/control/settings.html
+++ b/public/imperia/control/settings.html
@@ -528,29 +528,37 @@
         // Load tokens
         async function loadTokens() {
             try {
-                const response = await fetch('/api/tokens', {
+                const response = await fetch('/api/user/tokens', {
                     credentials: 'include'
                 });
                 
-                if (response.ok) {
-                    const data = await response.json();
-                    const apiTokenDisplay = document.getElementById('apiTokenDisplay');
+                const apiTokenDisplay = document.getElementById('apiTokenDisplay');
+                const remoteAccessDisplay = document.getElementById('remoteAccessDisplay');
+                
+                if (!response.ok) {
                     apiTokenDisplay.classList.remove('loading', 'show');
+                    remoteAccessDisplay.classList.remove('loading', 'show');
+                    apiTokenDisplay.innerHTML = '<p style="text-align: center; opacity: 0.6;">Nicht autorisiert</p>';
+                    remoteAccessDisplay.innerHTML = '<p style="text-align: center; opacity: 0.6;">Nicht autorisiert</p>';
+                    return;
+                }
+                
+                const data = await response.json();
+                apiTokenDisplay.classList.remove('loading', 'show');
+                
+                const token = data && data.token;
+                if (!token) {
+                    apiTokenDisplay.innerHTML = '<p style="text-align: center; opacity: 0.6;">Kein Token vorhanden</p>';
+                } else {
+                    apiTokenDisplay.innerHTML = `
+                        <div style="display: flex; align-items: center; gap: 12px;">
+                            <span style="font-weight: 600;">API Token =</span>
+                            <span style="font-family: monospace; background: rgba(255,255,255,0.1); padding: 8px 12px; border-radius: 6px;">${token}</span>
+                        </div>
+                    `;
                     
-                    if (data.tokens.length === 0) {
-                        apiTokenDisplay.innerHTML = '<p style="text-align: center; opacity: 0.6;">Kein Token vorhanden</p>';
-                    } else {
-                        const token = data.tokens[0].value;
-                        apiTokenDisplay.innerHTML = `
-                            <div style="display: flex; align-items: center; gap: 12px;">
-                                <span style="font-weight: 600;">API Token =</span>
-                                <span style="font-family: monospace; background: rgba(255,255,255,0.1); padding: 8px 12px; border-radius: 6px;">${token}</span>
-                            </div>
-                        `;
-                        
-                        // Update remote URLs
-                        updateRemoteUrl(token);
-                    }
+                    // Update remote URLs
+                    updateRemoteUrl(token);
                 }
             } catch (error) {
                 console.error('Error loading tokens:', error);
@@ -572,7 +580,7 @@
             remoteAccessDisplay.innerHTML = `
                 <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 16px;">
                     <span style="font-weight: 600;">Remote-Zugang =</span>
-                    <span style="font-family: monospace; background: rgba(255,255,255,0.1); padding: 8px 12px; border-radius: 6px;">${baseUrl}/imperia/remote/index.html?token=${token}</span>
+                    <span style="font-family: monospace; background: rgba(255,255,255,0.1); padding: 8px 12px; border-radius: 6px;">${baseUrl}/imperia/remote/${token}</span>
                 </div>
             `;
         }

--- a/public/imperia/sw.js
+++ b/public/imperia/sw.js
@@ -1,6 +1,6 @@
 // sw.js - Service Worker für IMPERIA Control System PWA
 // Updated: 2024-01-15
-const CACHE_NAME = 'imperia-control-v7-2024-01-15';
+const CACHE_NAME = 'imperia-control-v8-2025-08-18';
 const urlsToCache = [
   '/imperia/',
   '/imperia/control/index.html',

--- a/server.js
+++ b/server.js
@@ -498,7 +498,7 @@ app.get('/api/user/tokens', requireDB, async (req, res) => {
         const baseUrl = `${protocol}://${host}`;
 
         const apiExamples = {
-            remoteUrl: `${baseUrl}/imperia/remote/index.html?token=${token.token}`,
+            remoteUrl: `${baseUrl}/imperia/remote/${token.token}`,
             pushForce: {
                 url: `${baseUrl}/api/data/${token.token}`,
                 method: 'POST',


### PR DESCRIPTION
Fixes the display of API tokens and the IMPERIA Remote URL in settings by using the correct user-specific endpoint and updating the remote URL format.

The previous setup used an admin-only endpoint for fetching tokens and an incorrect URL format for the remote access, leading to blank fields in the settings for regular users.

---
<a href="https://cursor.com/background-agent?bcId=bc-7385e7cf-7b51-4490-82a9-5efd2ca302f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7385e7cf-7b51-4490-82a9-5efd2ca302f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

